### PR TITLE
BREAKING - Set cortex-m feature by default

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
+    - name: Build ( cortex-m )
+      run: cargo build --verbose --no-default-features
     - name: Run tests
-      run: cargo test --verbose
-    - name: Build for no_std
-      run: cargo build --no-default-features
+      run: cargo test --verbose --no-default-features
+    - name: Build
+      run: cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ cortex-m-rt = "0.7.5"
 embassy-time-driver = { version = "0.2", optional = true }
 
 [features]
-default = []
+default = ["cortex-m"]
 cortex-m = []
 embassy-defaults = [] # Set up a default/demo instance
 

--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ Embassy version:
 ```
 cargo runq --example embassy_time
 ```
+
+## Testing
+
+To run the tests, run without default features
+```
+cargo test --no-default-features
+```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ cargo runq --example embassy_time
 
 ## Testing
 
-To run the tests, run without default features
-```
+To run the tests, run without default features:
+```sh
 cargo test --no-default-features
-```


### PR DESCRIPTION
This resolves an issue I encountered when using this crate.

In the README, it is not documented that the cortex-m feature has to be enabled in order to avoid a panic on startup.

If your panic handler resets the chip (Or compiled with `panic=abort`), then the CPU will enter a reboot loop because of this.

It makes sense to enable the cortex-m feature by default since this is what this crate is targeting specifically. 

I have updated the README to show how to run the tests by disabling default features of the crate.

## Summary by Sourcery

Enable the `cortex-m` feature by default to avoid startup panics and update the README with testing instructions

Enhancements:
- Enable `cortex-m` feature by default in Cargo.toml

Build:
- Update default features in Cargo.toml to include `cortex-m`

Documentation:
- Add a Testing section to the README showing how to run tests with `--no-default-features`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default build features to enable "cortex-m" by default.

* **Documentation**
  * Added a "Testing" section to the README with instructions for running tests without default features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->