### PR TITLE
Fix the timer to be properly monotonic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systick-timer"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["kaidokert <kaidokert@gmail.com>"]

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -81,7 +81,7 @@ impl Timer {
         let (wraps_u64, final_val_u64) = if wraps_pre == wraps_post {
             // No ISR in window → VAL matches wraps_pre. COUNTFLAG may indicate a pending wrap.
             if self.read_systick_countflag() {
-                (wraps_pre + 1, v1)
+                (wraps_pre + 1, self.get_syst() as u64)
             } else {
                 (wraps_pre, v1)
             }


### PR DESCRIPTION
The only way to achieve monotonic updates here is to check csr COUNTFLAG - which adds an unsafe read.

## Summary by Sourcery

Ensure Timer.now returns monotonic timestamps by detecting pending SysTick wraps via COUNTFLAG and adjusting wrap count accordingly, refactor sampling logic, and add unit tests

Bug Fixes:
- Fix non-monotonic behavior of Timer.now across SysTick wraps

Enhancements:
- Refactor Timer.now to sample pre/post software counters and check COUNTFLAG for coherent wrap detection
- Introduce read_systick_countflag to atomically read and clear the hardware wrap flag
- Add test-only support for simulating COUNTFLAG in unit tests

Tests:
- Add unit tests verifying monotonicity around SysTick wrap and between interrupts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer accuracy and ensured time readings never move backward, even when the hardware counter wraps or interrupts are delayed.

* **Tests**
  * Added new tests to verify the timer's monotonicity and correctness around hardware wrap events and between interrupts.

* **Chores**
  * Updated package version to 0.1.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->