### PR TITLE
Bump version, test cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ cargo runq --example embassy_time
 To run the tests, run without default features:
 ```sh
 cargo test --no-default-features
+```
 
 ## Todo:
 

--- a/systick-timer/Cargo.toml
+++ b/systick-timer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systick-timer"
-version = "0.1.5"
+version = "0.2.1"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["kaidokert <kaidokert@gmail.com>"]

--- a/testapps/run_all_tests.py
+++ b/testapps/run_all_tests.py
@@ -37,7 +37,7 @@ class TestRunner:
         self.priority_options = ["priority-equal", "priority-systick-high", "priority-timer1-high", "priority-timer2-high", "priority-mixed-1", "priority-mixed-2", "priority-mixed-3", "priority-timers-high"]
 
         # Invalid configurations that violate design constraints
-        self.invalid_priorities = ["priority-timers-high"]
+        self.invalid_priorities = ["priority-timers-high", "priority-timer1-high", "priority-timer2-high"]
 
         self.results: List[TestResult] = []
         self.failed_tests: List[TestResult] = []


### PR DESCRIPTION
## Summary by Sourcery

Bump package version, refine test invalid priority list, and fix README formatting.

Enhancements:
- Expand the invalid_priorities list in run_all_tests.py to include priority-timer1-high and priority-timer2-high

Documentation:
- Add missing closing code block fence in README.md

Chores:
- Update systick-timer version from 0.1.5 to 0.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Markdown code fences so test command examples render properly. No behavioral changes.
* **Chores**
  * Updated the systick-timer package version to 0.2.1 with no dependency or feature changes.
* **Tests**
  * Expanded invalid priority configurations to include additional high-priority timer variants, causing more misconfigurations to be flagged by default and filtered during config generation. No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->